### PR TITLE
Adds missing dependency: requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ pip3 install placescraper
 
 ### Requirements
 
-* The `websocket-client` package from PyPI
+* The `requests` and `websocket-client` packages from PyPI
 * Python 3.X
 
 ### Running the scraper

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
     license='MIT',
     packages=[PACKAGE_NAME],
     install_requires=[
+        'requests',
         'websocket-client',
     ],
     test_suite='nose.collector',


### PR DESCRIPTION
The `requests` library is required to use `place-scraper`, but is not included in either the documentation or the setup script. This corrects the issue.